### PR TITLE
Fixing googles plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,4 @@ RemoteSystemsTempFiles
 .metadata
 .settings
 *.prefs
+.vscode/

--- a/plugins/google.py
+++ b/plugins/google.py
@@ -36,6 +36,6 @@ class Plugin:
     def __init__(self, app, conf):#
         global app_emailharvester, config
         #config = conf
-        app.register_plugin('googles', {'search': search})
+        app.register_plugin('google', {'search': search})
         app_emailharvester = app
         


### PR DESCRIPTION
For some reason, the plugin responsible for parsing from google has the name googles. Also google was mistyped, instead of google there was googles. 

Because of this the first example such as `EmailHarvester.py -d example.com -e google` doesn't work.