### PR TITLE
Fixing error TypeError: decode() argument 'encoding' must be str

### DIFF
--- a/plugins/ask.py
+++ b/plugins/ask.py
@@ -64,7 +64,10 @@ class AskSearch(object):
         except Exception as e:
             print(e)
             sys.exit(4)
-        
+
+        if r.encoding is None:
+	          r.encoding = 'UTF-8'
+
         self.results = r.content.decode(r.encoding)
         self.totalresults += self.results
     


### PR DESCRIPTION
Just a simple fix. Was running this on Kali WSL and noticed an error kept appearing. I think it's reasonable to add a simple default to utf-8.
Traceback (most recent call last):
  File "/home/bush/EmailHarvester/EmailHarvester.py", line 279, in <module>
    all_emails += plugins[search_engine]['search'](domain, limit)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/bush/EmailHarvester/plugins/ask.py", line 87, in search
    search.process()
  File "/home/bush/EmailHarvester/plugins/ask.py", line 73, in process
    self.do_search()
  File "/home/bush/EmailHarvester/plugins/ask.py", line 68, in do_search
    self.results = r.content.decode(r.encoding)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: decode() argument 'encoding' must be str, not None